### PR TITLE
hal: Remove ndk_platform backend. Use the ndk backend.

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -385,7 +385,7 @@ endif
 
 LOCAL_SHARED_LIBRARIES += libbase libhidlbase libutils android.hardware.power@1.2 liblog
 
-LOCAL_SHARED_LIBRARIES += android.hardware.power-V2-ndk_platform
+LOCAL_SHARED_LIBRARIES += android.hardware.power-V2-ndk
 LOCAL_SHARED_LIBRARIES += libbinder_ndk
 
 LOCAL_SRC_FILES += audio_perf.cpp


### PR DESCRIPTION
The ndk_platform backend will soon be deprecated because the ndk backend
can serve the same purpose. This is to eliminate the confusion about
having two variants (ndk and ndk_platform) for the same ndk backend.

Bug: 161456198
Test: m
Merged-In: Iebc1c5d4c277e96cf7564d882aeecb084adc53ee
Change-Id: Iebc1c5d4c277e96cf7564d882aeecb084adc53ee
(cherry picked from commit 25368375b1759a13cacbfa1a9a183d4eee7381b2)